### PR TITLE
fix: #127 and #161

### DIFF
--- a/i18n/languages.json
+++ b/i18n/languages.json
@@ -82,6 +82,7 @@
         "redirect-title": "Quick Redirect",
         "notify-redirect-success": "Redirect successful.",
         "notify-redirect-error": "Some error(s) occurred while creating redirect",
+        "notify-redirect-converted-error": "A page of the target name or its converted name already exists. Please choose another name.",
         "delete-reason-default": "No longer used",
         "delete-title": "Quick Delete",
         "delete-no-right": "You do NOT have permission to delete the page.",

--- a/src/module/quickRedirect.js
+++ b/src/module/quickRedirect.js
@@ -105,7 +105,7 @@ var quickRedirect = function (type = 'to') {
           $('.in-page-edit.quick-redirect .okBtn').attr('disabled', 'disabled')
 
           let promise = Promise.resolve()
-          if (window.InPageEdit?.noRedirectIfConvertedTitleExists) {
+          if (preference.get('noRedirectIfConvertedTitleExists')) {
             promise = mwApi.get({ titles: json.title, converttitles: 1, formatversion: 2 }).done(data => {
               const convertedTitle = data.query.pages[0]
               if (convertedTitle?.missing !== true) {

--- a/src/module/quickRedirect.js
+++ b/src/module/quickRedirect.js
@@ -106,7 +106,7 @@ var quickRedirect = function (type = 'to') {
 
           let promise = Promise.resolve()
           if (window.InPageEdit?.noRedirectIfConvertedTitleExists) {
-            promise = mwApi.get({ titles: json.title, converttitles: 1 }).done(data => {
+            promise = mwApi.get({ titles: json.title, converttitles: 1, formatversion: 2 }).done(data => {
               const convertedTitle = data.query.pages[0]
               if (convertedTitle?.missing !== true) {
                 failed('articleexists', { fromPage: convertedTitle.title, errors: [{

--- a/src/module/quickRedirect.js
+++ b/src/module/quickRedirect.js
@@ -104,7 +104,24 @@ var quickRedirect = function (type = 'to') {
           $('.in-page-edit.quick-redirect section').hide()
           $('.in-page-edit.quick-redirect .okBtn').attr('disabled', 'disabled')
 
-          mwApi.postWithToken('csrf', json).done(successed).fail(failed)
+          let promise = Promise.resolve()
+          if (window.InPageEdit?.noRedirectIfConvertedTitleExists) {
+            promise = mwApi.get({ titles: json.title, converttitles: 1 }).done(data => {
+              const convertedTitle = data.query.pages[0]
+              if (convertedTitle?.missing !== true) {
+                failed('articleexists', { fromPage: convertedTitle.title, errors: [{
+                  '*':  _msg('notify-redirect-converted-error')
+                }] })
+                throw null
+              }
+            }).fail((errorCode, errorThrown) => {
+              failed(errorCode, errorThrown)
+              throw null
+            })
+          }
+          promise.then(() => {
+            mwApi.postWithToken('csrf', json).done(successed).fail(failed)
+          }, () => {})
           // 重定向成功
           function successed(data) {
             if (data.errors) {
@@ -147,10 +164,10 @@ var quickRedirect = function (type = 'to') {
             if (errorCode === 'articleexists') {
               var fromPage, toPage
               if (type === 'from') {
-                fromPage = target
+                fromPage = errorThrown.fromPage ?? target
                 toPage = config.wgPageName
               } else if (type === 'to') {
-                fromPage = config.wgPageName
+                fromPage = errorThrown.fromPage ?? config.wgPageName
                 toPage = target
               }
               _resolveExists(fromPage, {

--- a/src/module/quickRename.js
+++ b/src/module/quickRename.js
@@ -58,7 +58,7 @@ var quickRename = function (from, to) {
       $br,
 
       $('<label>').append(
-        $('<input>', { type: 'checkbox', id: 'noredirect' }),
+        $('<input>', { type: 'checkbox', id: 'noredirect', disabled: !_hasRight('suppressredirect') }),
         $('<span>', { text: _msg('rename-noredirect') })
       )
     ),


### PR DESCRIPTION
Issue #127 :
Stop redirecting if a converted title of the target page exists, only when manually setting InPageEdit.noRedirectIfConvertedTitleExists = true
No changes if not setting InPageEdit.noRedirectIfConvertedTitleExists