### PR TITLE
fix: #150 and #163

### DIFF
--- a/src/module/articleLink.js
+++ b/src/module/articleLink.js
@@ -45,7 +45,7 @@ function articleLink(el) {
       title = url.slice(location.protocol.length + config.wgServer.length)
       title = title.split('?')[0]
       const escape = mw.util.escapeRegExp ?? mw.RegExp.escape
-      const articlePath = RegExp(mw.util.escapeRegExp(config.wgArticlePath).replace('\\$1', '(.+)'))
+      const articlePath = RegExp(escape(config.wgArticlePath).replace('\\$1', '(.+)'))
       if (title.startsWith(config.wgScript))
         title = decodeURIComponent(title.slice(config.wgScript.length + 1))
       else if (articlePath.test(title))

--- a/src/module/articleLink.js
+++ b/src/module/articleLink.js
@@ -58,7 +58,7 @@ function articleLink(el) {
             text: _msg('quick-edit'),
           }).on('click', function () {
             var options = {}
-            options.page = decodeURI(title)
+            options.page = title
             if (revision !== null) {
               options.revision = revision
             } else if (section !== null) {

--- a/src/module/articleLink.js
+++ b/src/module/articleLink.js
@@ -22,7 +22,8 @@ function articleLink(el) {
   $.each(el, function (_, item) {
     var $this = $(item)
     if ($this.attr('href') === undefined) return
-    let url = $this.attr('href'),
+    // element.href必定带protocol
+    let url = $this[0].href,
       action = getParamValue('action', url) || getParamValue('veaction', url),
       title = getParamValue('title', url),
       section = getParamValue('section', url)
@@ -31,8 +32,7 @@ function articleLink(el) {
       revision = getParamValue('oldid', url)
 
     // 不是本地编辑链接
-    if (!RegExp('^' + config.wgServer).test(url) && !RegExp('^/').test(url))
-      return
+    if (!url.startsWith(`${location.protocol}${config.wgServer}/`)) return
 
     // 暂时屏蔽 section=new #137
     if (section === 'new') return
@@ -41,10 +41,16 @@ function articleLink(el) {
     if (getParamValue('undo', url)) return
 
     // 不是 index.php?title=FOO 形式的url
-    if (title === null) {
-      title = url.replace(config.wgServer, '')
+    if (title === null && action === 'edit') {
+      title = url.slice(location.protocol.length + config.wgServer.length)
       title = title.split('?')[0]
-      title = title.replace(config.wgArticlePath.replace('$1', ''), '')
+      const escape = mw.util.escapeRegExp ?? mw.RegExp.escape
+      const articlePath = RegExp(mw.util.escapeRegExp(config.wgArticlePath).replace('\\$1', '(.+)'))
+      if (title.startsWith(config.wgScript))
+        title = decodeURIComponent(title.slice(config.wgScript.length + 1))
+      else if (articlePath.test(title))
+        title = decodeURIComponent(title.match(articlePath)[1])
+      else title = undefined
     }
 
     if (action === 'edit' && title !== undefined) {

--- a/src/module/quickEdit.js
+++ b/src/module/quickEdit.js
@@ -58,7 +58,6 @@ var quickEdit = function (options) {
 
   /** 将选项合并并标准化 **/
   options = $.extend({}, defaultOptions, options, userPreference)
-  options.page = decodeURI(options.page) // 解码网址 Unicode
 
   _analysis('quick_edit')
 


### PR DESCRIPTION
The "page" property is or is supposed to be the unencoded page name in all direct/indirect references of the InPageEdit.quickEdit method:
1. plugins/edit-any-page.js (user input)
2. plugins/toolbox.js (wgPageName)
3. loadQuickDiff.js (wgPageName)
4. linksHere.js (API returned title)
5. quickRedirect.js (through _resolveExists.js; user input, or wgPageName, or API returned title)
6. quickRename.js (through _resolveExists.js; user input)
7. articleLink.js (mw.util.getParamValue, which includes a decodeURIComponent function; or decodeURIComponent)