### PR TITLE
feat: create _error.js

### DIFF
--- a/src/module/_error.js
+++ b/src/module/_error.js
@@ -1,0 +1,12 @@
+function _error(code, result) {
+	if (code === 'http') {
+		return result.exception || result.textStatus
+	} else if (code === 'okay-but-empty') {
+		return result
+	}
+	return result.errors[0].html
+}
+
+module.exports = {
+	_error,
+}


### PR DESCRIPTION
Standardize API error handling. Whether to use "html" or "plaintext" is to be discussed.