### PR TITLE
fix: do not intercept clicks with modifier keys pressed

### DIFF
--- a/src/module/loadQuickDiff.js
+++ b/src/module/loadQuickDiff.js
@@ -109,6 +109,10 @@ const loadQuickDiff = function (container) {
       $('<button>')
         .text(_msg('quick-diff'))
         .on('click', function (e) {
+          if (e.ctrlKey || e.altKey || e.shiftKey || e.metaKey) {
+            return
+          }
+
           e.preventDefault()
           _analytics('quick_diff_history_page')
           const before = $('.selected.before').attr('data-mw-revid'),


### PR DESCRIPTION
Quick diff should be disabled when any modifier key (<kbd>Ctrl</kbd>, <kbd>Shift</kbd>, <kbd>Alt</kbd>, <kbd>Meta</kbd>) is pressed. This allows users to view pages as usual via opening them in new tabs/windows, when IPE is not working due to e.g. rate limit.