### PR TITLE
feat(articleLink.js): support section-0 link

### DIFF
--- a/src/module/articleLink.js
+++ b/src/module/articleLink.js
@@ -13,9 +13,9 @@ const { getParamValue } = mw.util
 function articleLink(el) {
   if (!el) {
     if (preference.get('redLinkQuickEdit') === true) {
-      el = $('#mw-content-text a')
+      el = $('#mw-content-text a, #firstHeading a')
     } else {
-      el = $('#mw-content-text a:not(.new)')
+      el = $('#mw-content-text a:not(.new), #firstHeading a:not(.new)')
     }
   }
   /** @type {JQuery<HTMLAnchorElement>} */


### PR DESCRIPTION
Vector-2022 adds a new editing link after the heading.