### PR TITLE
fix: substring error in iwlink cases

### DIFF
--- a/src/module/articleLink.js
+++ b/src/module/articleLink.js
@@ -23,8 +23,7 @@ function articleLink(elements) {
     const rawHref = anchor.getAttribute('href')
     if (
       !rawHref ||
-      rawHref.startsWith('#') ||
-      rawHref.startsWith('javascript:')
+      /^(?:#|javascript:|vbscript:|data:)/i.test(rawHref)
     ) {
       return
     }

--- a/src/module/articleLink.js
+++ b/src/module/articleLink.js
@@ -30,20 +30,28 @@ function articleLink(elements) {
     }
 
     // 缓存wiki相关变量
-    // prettier-ignore
-    const articlePath = config.wgArticlePath.replace('$1', ''),
+    const href = anchor.href,
+      articlePath = config.wgArticlePath.replace('$1', ''),
       wikiBaseURL = `${location.protocol}//${config.wgServer.split('//')[1]}`,
       wikiArticleBaseURL = `${wikiBaseURL}${articlePath}`,
       wikiScriptBaseURL = `${wikiBaseURL}${config.wgScriptPath}`
+
+    // 链接指向的既不是本wiki的 canonicalurl 也不是 permalink
+    if (
+      !href.startsWith(wikiArticleBaseURL) &&
+      !href.startsWith(wikiScriptBaseURL)
+    ) {
+      return
+    }
+
     // 缓存链接相关变量
-    // prettier-ignore
-    const href = anchor.href,
-      anchorURL = new URL(href),
+    const anchorURL = new URL(href),
       params = anchorURL.searchParams,
       action = params.get('action') || params.get('veaction'),
-      title = params.get('title') ||
-              decodeURI(anchorURL.pathname.substring(articlePath.length)) ||
-              null,
+      title =
+        params.get('title') ||
+        decodeURI(anchorURL.pathname.substring(articlePath.length)) ||
+        null,
       section = params.get('section')?.replace(/^T-/, '') || null,
       revision = params.get('oldid')
 
@@ -51,12 +59,9 @@ function articleLink(elements) {
     // prettier-ignore
     if (
       // 不合法的 title
-      !title ||
-      title.endsWith('.php') ||
+      !title || title.endsWith('.php') ||
       // 不是 edit 相关操作
       !['edit', 'editsource'].includes(action) ||
-      // 链接指向的既不是本wiki的 canonicalurl 也不是 permalink
-      !(href.startsWith(wikiArticleBaseURL) || href.startsWith(wikiScriptBaseURL)) ||
       // 暂时未兼容 undo
       params.get('undo') ||
       // 暂时未兼容 preload


### PR DESCRIPTION
在特定情况下，substring将连接中的百分号错误切割