### PR TITLE
fix(quickEdit.js): do not set esc key twice

### DIFF
--- a/src/module/quickEdit.js
+++ b/src/module/quickEdit.js
@@ -331,7 +331,6 @@ var quickEdit = function (options) {
       {
         label: _msg('cancel'),
         className: 'btn btn-danger',
-        keyPress: 'escape',
         method(e, modal) {
           modal.close()
         },


### PR DESCRIPTION
[The esc key has already been set on all ssi-modal windows which have a close icon](https://github.com/inpageedit/Plugins/blob/master/src/lib/ssi-modal/ssi-modal.js#L156-L164).