### PR TITLE
fix(quickEdit): conform to formatversion=2

### DIFF
--- a/src/module/quickEdit.js
+++ b/src/module/quickEdit.js
@@ -560,7 +560,7 @@ export function quickEdit(options) {
             $optionsLabel
               .find('.watchList')
               .prop('disabled', false)
-              .prop('checked', 'watched' in pageData)
+              .prop('checked', pageData.watched)
               .off('click')
               .removeAttr('title')
           }


### PR DESCRIPTION
pageData.watched is always there as a boolean