### PR TITLE
fix(quickEdit): prevent being shown twice

### DIFF
--- a/src/module/quickEdit.js
+++ b/src/module/quickEdit.js
@@ -382,6 +382,7 @@ export function quickEdit(options) {
      * @description 模态框显示后
      */
     onShow($modal) {
+      $modal.options.onShow = '';
       var $modalWindow = $('#' + $modal.modalId)
       mw.hook('InPageEdit.quickEdit').fire({
         $modal,


### PR DESCRIPTION
`InPageEdit.quickEdit`有时会错误地多次调用`onShow`函数，但我没能准确定位原因，因此提出这项临时修复措施。我假设了`quickEdit`模态框只会被关闭而不会被隐藏，如果真有被隐藏的情形请告知我。