### PR TITLE
fix(preference): fixed savelocal note typo

### DIFF
--- a/src/module/preference.js
+++ b/src/module/preference.js
@@ -133,7 +133,7 @@ export const preference = {
             this.select()
           })
           .val(
-            `/** InPageEdit Preferences */\n;(window.InPageEdit = window.InPageEdit || {}).myPreference = ${JSON.stringify(
+            `/** InPageEdit Preferences **/\n;(window.InPageEdit = window.InPageEdit || {}).myPreference = ${JSON.stringify(
               $modalContent.data(),
               null,
               2


### PR DESCRIPTION
好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

Bug 修复:
- 修正了 'savelocal note' 注释中的一个拼写错误，改为 'save local note'。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Corrects a typo in the 'savelocal note' comment to 'save local note'.

</details>