### PR TITLE
fix: quickDiff button style

### DIFF
--- a/src/module/loadQuickDiff.js
+++ b/src/module/loadQuickDiff.js
@@ -108,6 +108,7 @@ export function loadQuickDiff(container) {
     $('.historysubmit.mw-history-compareselectedversions-button').after(
       $('<button>')
         .text(_msg('quick-diff'))
+        .addClass('cdx-button')
         .on('click', function (e) {
           if (!isPureLMBClick(e)) return
 

--- a/src/module/loadQuickDiff.js
+++ b/src/module/loadQuickDiff.js
@@ -108,7 +108,7 @@ export function loadQuickDiff(container) {
     $('.historysubmit.mw-history-compareselectedversions-button').after(
       $('<button>')
         .text(_msg('quick-diff'))
-        .addClass('cdx-button')
+        .addClass('cdx-button mw-ui-button')
         .on('click', function (e) {
           if (!isPureLMBClick(e)) return
 


### PR DESCRIPTION
## Sourcery 摘要

Bug 修复：
- 为快速差异按钮添加缺失的 `cdx-button` 类，以实现一致的样式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Add missing cdx-button class to the quick diff button for consistent styling

</details>